### PR TITLE
本番環境でcompileをtrueに設定

### DIFF
--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -83,7 +83,7 @@ production:
   <<: *default
 
   # Production depends on precompilation of packs prior to booting for performance.
-  compile: false
+  compile: true
 
   # Extract and emit a css file
   extract_css: true


### PR DESCRIPTION
## 概要
- アプリケーションデプロイ時、assetディレクトリ配下が読み込まれていないので、本番環境でもcompileをtrueにする