### PR TITLE
fix: productionではscoketをみないように修正

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -15,11 +15,11 @@ default: &default
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   username: root
   password:
-  socket: /tmp/mysql.sock
 
 development:
   <<: *default
   database: raisetech_live8_sample_app_development
+  socket: /tmp/mysql.sock
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
@@ -27,6 +27,7 @@ development:
 test:
   <<: *default
   database: raisetech_live8_sample_app_test
+  socket: /tmp/mysql.sock
 
 # As with config/credentials.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is


### PR DESCRIPTION
## 概要
- database.ymlにおいてproductionではdefaultのsocketを継承しないように修正