### PR TITLE
database.ymlの元ファイルではなく、sampleファイルをcommitするように修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ pickle-email-*.html
 # TODO Comment out this rule if you are OK with secrets being uploaded to the repo
 config/initializers/secret_token.rb
 config/master.key
+config/database.yml
 
 # Only include if you have production secrets in this file, which is no longer a Rails default
 # config/secrets.yml

--- a/config/database.yml.sample
+++ b/config/database.yml.sample
@@ -14,7 +14,7 @@ default: &default
   encoding: utf8mb4
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   username: root
-  password: J.EDhPWuKxidQBJdFVFtmiRRaf9
+  password: 
 
 development:
   <<: *default


### PR DESCRIPTION
## 概要
- database.ymlは秘匿情報を記載するためセキュリティリスク考慮
- developmentについてはclone先ごとに異なるため、誤ってcommitしないようにする
- 本PRをMerge後はconfig/database.yml.sampleをconfig/database.ymlにcpする