### PR TITLE
Cloud9でのrails server起動用にbinファイルとProcfileの作成およびREADMEの更新

### DIFF
--- a/Procfile.cloud9dev
+++ b/Procfile.cloud9dev
@@ -1,0 +1,2 @@
+web: bin/rails server -p 8080 -b 0.0.0.0
+js: yarn build --watch

--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@
 3.1.2
 ```
 
+### Bundler
+```bash
+2.3.14
+```
+
 ### Rails
 
 ```bash
@@ -32,6 +37,24 @@ v18.11.0
 
 ### DB エンジン
 
-- MySQL
-- Cloud9 上で動作させる場合は、下記から HTML をダウンロードし、その手順に沿って環境構築を行ってください。
-  https://onedrive.live.com/?authkey=%21AJUub1X2ubpj9Qc&cid=D2DFE9880240895A&id=D2DFE9880240895A%2126879&parId=D2DFE9880240895A%211376&o=OneUp
+- MySQLを採用しています。
+  - Cloud9 上で動作させる場合は、下記の手順に沿って環境構築を行ってください。
+    - https://github.com/MasatoshiMizumoto/raisetech_documents/blob/main/aws/docs/install_mysql_on_cloud9_amazon_linux_2.md
+
+### 環境構築
+- 環境構築はターミナルで以下のコマンドを実行することで可能になります。
+```bash
+bin/setup
+```
+
+### アプリケーションサーバーの起動
+- railsサーバーの起動は実行環境に合わせて以下のコマンドを実行してください
+#### ローカル環境
+```bash
+bin/dev
+```
+
+#### Cloud9
+```bash
+bin/cloud9_dev
+```

--- a/bin/cloud9_dev
+++ b/bin/cloud9_dev
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+if ! foreman version &> /dev/null
+then
+  echo "Installing foreman..."
+  gem install foreman
+fi
+
+foreman start -f Procfile.cloud9dev "$@"


### PR DESCRIPTION
## 概要
- Cloud9で本アプリケーションを実行する際、Port番号などが異なるため専用のbinファイルとProcfileを作成
- 上記作成に伴い、READMEを更新