### PR TITLE
storage.ymlからアクセスキー・シークレットキーの記述を削除

### DIFF
--- a/config/storage.yml
+++ b/config/storage.yml
@@ -9,10 +9,8 @@ local:
 # Use rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
 amazon:
  service: S3
- access_key_id: <%= Rails.application.credentials.dig(:aws, :access_key_id) %>
- secret_access_key: <%= Rails.application.credentials.dig(:aws, :secret_access_key) %>
  region: ap-northeast-1
- bucket: <%= Rails.application.credentials.dig(:aws, :active_storage_bucket_name) %>
+ bucket: <%= ENV['AWS_S3_BUCKET_NAME'] %>
 
 # Remember not to checkin your GCS keyfile to a repository
 # google:


### PR DESCRIPTION
## 概要
- config/storage.ymlにアクセスキーとシークレットキーを記載する記述があるが、EC2前提とするならIAMロールをアタッチすれば不要となるので記述を削除する