### PR TITLE
Add systemd setting for puma

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ gem 'unicorn'
 gem 'net-smtp'
 gem 'jsbundling-rails'
 gem 'turbo-rails'
+gem 'sd_notify'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -212,6 +212,7 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
+    sd_notify (0.1.1)
     slim (4.1.0)
       temple (>= 0.7.6, < 0.9)
       tilt (>= 2.0.6, < 2.1)
@@ -274,6 +275,7 @@ DEPENDENCIES
   redis (~> 4.0)
   rspec-rails (~> 4.0.2)
   sass-rails (>= 6)
+  sd_notify
   slim-rails
   spring
   turbo-rails

--- a/samples/puma.service.sample
+++ b/samples/puma.service.sample
@@ -1,0 +1,48 @@
+[Unit]
+Description=Puma HTTP Server
+After=network.target
+
+# Uncomment for socket activation (see below)
+# Requires=puma.socket
+
+[Service]
+# Puma supports systemd's `Type=notify` and watchdog service
+# monitoring, if the [sd_notify](https://github.com/agis/ruby-sdnotify) gem is installed,
+# as of Puma 5.1 or later.
+# On earlier versions of Puma or JRuby, change this to `Type=simple` and remove
+# the `WatchdogSec` line.
+Type=notify
+
+# If your Puma process locks up, systemd's watchdog will restart it within seconds.
+WatchdogSec=10
+
+# Preferably configure a non-privileged user
+User=ec2-user
+
+# The path to the your application code root directory.
+# Also replace the "<YOUR_APP_PATH>" place holders below with this path.
+# Example /home/username/myapp
+WorkingDirectory=/home/ec2-user/raisetech-live8-sample-app
+
+# Helpful for debugging socket activation, etc.
+# Environment=PUMA_DEBUG=1
+Environment="PATH=/home/ec2-user/.anyenv/bin:/home/ec2-user/.anyenv/envs/rbenv/shims:/home/ec2-user/.anyenv/envs/rbenv/bin:/home/ec2-user/.anyenv/envs/rbenv/bin:/home/ec2-user/.anyenv/envs/nodenv/shims:/home/ec2-user/.anyenv/envs/nodenv/bin:/home/ec2-user/.anyenv/bin:/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/home/ec2-user/.local/bin:/home/ec2-user/bin"
+
+# SystemD will not run puma even if it is in your path. You must specify
+# an absolute URL to puma. For example /usr/local/bin/puma
+# Alternatively, create a binstub with `bundle binstubs puma --path ./sbin` in the WorkingDirectory
+#ExecStart=/<FULLPATH>/bin/puma -C <YOUR_APP_PATH>/puma.rb
+
+# Variant: Rails start.
+# ExecStart=/<FULLPATH>/bin/puma -C <YOUR_APP_PATH>/config/puma.rb ../config.ru
+ExecStart=/home/ec2-user/raisetech-live8-sample-app/sbin/puma -C /home/ec2-user/raisetech-live8-sample-app/config/puma.rb /home/ec2-user/raisetech-live8-sample-app/config.ru
+
+# Variant: Use `bundle exec --keep-file-descriptors puma` instead of binstub
+# Variant: Specify directives inline.
+# ExecStart=/<FULLPATH>/puma -b tcp://0.0.0.0:9292 -b ssl://0.0.0.0:9293?key=key.pem&cert=cert.pem
+
+
+Restart=always
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## 概要
- Rubyの3.2系にunicornが対応していないため、pumaをAPサーバーとして起動させるためにsystemdのserviceファイルを作成
- これによりdaemonizeすることができる
- 利用する際にはサンプルファイルをにcopyして`/etc/systemd/system/puma.service`に設置する 